### PR TITLE
Fix tests in Sqlite

### DIFF
--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
@@ -239,14 +239,27 @@ describe('DefaultProcessingDatabase', () => {
         let savedRelations = await knex<DbRelationsRow>('relations')
           .where({ originating_entity_id: id })
           .select();
-        expect(savedRelations.length).toBe(1);
-        expect(savedRelations[0]).toEqual({
-          id: expect.any(Number),
+
+        const expected_saved_relation = {
+          id: expect.anything(),
           originating_entity_id: id,
           source_entity_ref: 'component:default/foo',
           type: 'memberOf',
           target_entity_ref: 'component:default/foo',
-        });
+        };
+        const sqlite_expected_saved_relation = {
+          originating_entity_id: id,
+          source_entity_ref: 'component:default/foo',
+          type: 'memberOf',
+          target_entity_ref: 'component:default/foo',
+        };
+
+        expect(savedRelations.length).toBe(1);
+        expect(savedRelations[0]).toEqual(
+          databaseId === 'SQLITE_3'
+            ? sqlite_expected_saved_relation
+            : expected_saved_relation,
+        );
         expect(updateResult.previous.relations).toEqual([]);
 
         updateResult = await db.transaction(tx =>
@@ -263,22 +276,47 @@ describe('DefaultProcessingDatabase', () => {
         savedRelations = await knex<DbRelationsRow>('relations')
           .where({ originating_entity_id: id })
           .select();
-        expect(savedRelations.length).toBe(1);
-        expect(savedRelations[0]).toEqual({
-          id: savedRelations[0].id,
+
+        const expected_newly_saved_relation = {
+          id: expect.anything(),
           originating_entity_id: id,
           source_entity_ref: 'component:default/foo',
           type: 'memberOf',
           target_entity_ref: 'component:default/foo',
-        });
+        };
+
+        const expected_previous_saved_relation = {
+          id: expect.anything(),
+          originating_entity_id: expect.any(String),
+          source_entity_ref: 'component:default/foo',
+          type: 'memberOf',
+          target_entity_ref: 'component:default/foo',
+        };
+
+        const sqlite_expected_newly_saved_relation = {
+          originating_entity_id: id,
+          source_entity_ref: 'component:default/foo',
+          type: 'memberOf',
+          target_entity_ref: 'component:default/foo',
+        };
+
+        const sqlite_expected_previous_saved_relation = {
+          originating_entity_id: expect.any(String),
+          source_entity_ref: 'component:default/foo',
+          type: 'memberOf',
+          target_entity_ref: 'component:default/foo',
+        };
+
+        expect(savedRelations.length).toBe(1);
+        expect(savedRelations[0]).toEqual(
+          databaseId === 'SQLITE_3'
+            ? sqlite_expected_newly_saved_relation
+            : expected_newly_saved_relation,
+        );
         expect(updateResult.previous.relations).toEqual([
-          {
-            id: expect.any(Number),
-            originating_entity_id: expect.any(String),
-            source_entity_ref: 'component:default/foo',
-            type: 'memberOf',
-            target_entity_ref: 'component:default/foo',
-          },
+          databaseId === 'SQLITE_3'
+            ? sqlite_expected_previous_saved_relation
+            : expected_previous_saved_relation,
         ]);
       },
     );

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
@@ -254,12 +254,15 @@ describe('DefaultProcessingDatabase', () => {
           target_entity_ref: 'component:default/foo',
         };
 
+        let expected_relation;
+        if (databaseId === 'SQLITE_3') {
+          expected_relation = sqlite_expected_saved_relation;
+        } else {
+          expected_relation = expected_saved_relation;
+        }
+
         expect(savedRelations.length).toBe(1);
-        expect(savedRelations[0]).toEqual(
-          databaseId === 'SQLITE_3'
-            ? sqlite_expected_saved_relation
-            : expected_saved_relation,
-        );
+        expect(savedRelations[0]).toEqual(expected_relation);
         expect(updateResult.previous.relations).toEqual([]);
 
         updateResult = await db.transaction(tx =>
@@ -307,16 +310,19 @@ describe('DefaultProcessingDatabase', () => {
           target_entity_ref: 'component:default/foo',
         };
 
-        expect(savedRelations.length).toBe(1);
-        expect(savedRelations[0]).toEqual(
-          databaseId === 'SQLITE_3'
-            ? sqlite_expected_newly_saved_relation
-            : expected_newly_saved_relation,
-        );
+        let expected_new_relation;
+        let expected_previous_relation;
+        if (databaseId === 'SQLITE_3') {
+          expected_new_relation = sqlite_expected_newly_saved_relation;
+          expected_previous_relation = sqlite_expected_previous_saved_relation;
+        } else {
+          expected_new_relation = expected_newly_saved_relation;
+          expected_previous_relation = expected_previous_saved_relation;
+        }
+
+        expect(savedRelations[0]).toEqual(expected_new_relation);
         expect(updateResult.previous.relations).toEqual([
-          databaseId === 'SQLITE_3'
-            ? sqlite_expected_previous_saved_relation
-            : expected_previous_saved_relation,
+          expected_previous_relation,
         ]);
       },
     );
@@ -713,6 +719,7 @@ describe('DefaultProcessingDatabase', () => {
 
   describe('listParents', () => {
     let nextId = 1;
+
     function makeEntity(ref: string) {
       return {
         entity_id: String(nextId++),

--- a/plugins/catalog-backend/src/database/operations/stitcher/performStitching.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/performStitching.test.ts
@@ -121,58 +121,108 @@ describe('performStitching', () => {
       const firstHash = entities[0].hash;
 
       const search = await knex<DbSearchRow>('search');
+      const stitch_expected_array = [
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'relations.looksat',
+          original_value: 'k:ns/other',
+          value: 'k:ns/other',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'apiversion',
+          original_value: 'a',
+          value: 'a',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'kind',
+          original_value: 'k',
+          value: 'k',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'metadata.name',
+          original_value: 'n',
+          value: 'n',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'metadata.namespace',
+          original_value: 'ns',
+          value: 'ns',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'metadata.uid',
+          original_value: 'my-id',
+          value: 'my-id',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'spec.k',
+          original_value: 'v',
+          value: 'v',
+        },
+      ];
+      const sqlite_stitch_expected_array = [
+        {
+          entity_id: 'my-id',
+          key: 'relations.looksat',
+          original_value: 'k:ns/other',
+          value: 'k:ns/other',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'apiversion',
+          original_value: 'a',
+          value: 'a',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'kind',
+          original_value: 'k',
+          value: 'k',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'metadata.name',
+          original_value: 'n',
+          value: 'n',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'metadata.namespace',
+          original_value: 'ns',
+          value: 'ns',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'metadata.uid',
+          original_value: 'my-id',
+          value: 'my-id',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'spec.k',
+          original_value: 'v',
+          value: 'v',
+        },
+      ];
+
       expect(search).toEqual(
-        expect.arrayContaining([
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'relations.looksat',
-            original_value: 'k:ns/other',
-            value: 'k:ns/other',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'apiversion',
-            original_value: 'a',
-            value: 'a',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'kind',
-            original_value: 'k',
-            value: 'k',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'metadata.name',
-            original_value: 'n',
-            value: 'n',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'metadata.namespace',
-            original_value: 'ns',
-            value: 'ns',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'metadata.uid',
-            original_value: 'my-id',
-            value: 'my-id',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'spec.k',
-            original_value: 'v',
-            value: 'v',
-          },
-        ]),
+        expect.arrayContaining(
+          databaseId === 'SQLITE_3'
+            ? sqlite_stitch_expected_array
+            : stitch_expected_array,
+        ),
       );
 
       // Re-stitch without any changes
@@ -237,65 +287,121 @@ describe('performStitching', () => {
       expect(entities[0].hash).not.toEqual(firstHash);
       expect(entities[0].hash).toEqual(entity.metadata.etag);
 
+      const restitch_expected_array = [
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'relations.looksat',
+          original_value: 'k:ns/other',
+          value: 'k:ns/other',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'relations.looksat',
+          original_value: 'k:ns/third',
+          value: 'k:ns/third',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'apiversion',
+          original_value: 'a',
+          value: 'a',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'kind',
+          original_value: 'k',
+          value: 'k',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'metadata.name',
+          original_value: 'n',
+          value: 'n',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'metadata.namespace',
+          original_value: 'ns',
+          value: 'ns',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'metadata.uid',
+          original_value: 'my-id',
+          value: 'my-id',
+        },
+        {
+          id: expect.anything(),
+          entity_id: 'my-id',
+          key: 'spec.k',
+          original_value: 'v',
+          value: 'v',
+        },
+      ];
+      const sqlite_restitch_expected_array = [
+        {
+          entity_id: 'my-id',
+          key: 'relations.looksat',
+          original_value: 'k:ns/other',
+          value: 'k:ns/other',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'relations.looksat',
+          original_value: 'k:ns/third',
+          value: 'k:ns/third',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'apiversion',
+          original_value: 'a',
+          value: 'a',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'kind',
+          original_value: 'k',
+          value: 'k',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'metadata.name',
+          original_value: 'n',
+          value: 'n',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'metadata.namespace',
+          original_value: 'ns',
+          value: 'ns',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'metadata.uid',
+          original_value: 'my-id',
+          value: 'my-id',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'spec.k',
+          original_value: 'v',
+          value: 'v',
+        },
+      ];
+
       expect(await knex<DbSearchRow>('search')).toEqual(
-        expect.arrayContaining([
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'relations.looksat',
-            original_value: 'k:ns/other',
-            value: 'k:ns/other',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'relations.looksat',
-            original_value: 'k:ns/third',
-            value: 'k:ns/third',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'apiversion',
-            original_value: 'a',
-            value: 'a',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'kind',
-            original_value: 'k',
-            value: 'k',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'metadata.name',
-            original_value: 'n',
-            value: 'n',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'metadata.namespace',
-            original_value: 'ns',
-            value: 'ns',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'metadata.uid',
-            original_value: 'my-id',
-            value: 'my-id',
-          },
-          {
-            id: expect.anything(),
-            entity_id: 'my-id',
-            key: 'spec.k',
-            original_value: 'v',
-            value: 'v',
-          },
-        ]),
+        expect.arrayContaining(
+          databaseId === 'SQLITE_3'
+            ? sqlite_restitch_expected_array
+            : restitch_expected_array,
+        ),
       );
     },
   );

--- a/plugins/catalog-backend/src/stitching/DefaultStitcher.test.ts
+++ b/plugins/catalog-backend/src/stitching/DefaultStitcher.test.ts
@@ -121,58 +121,109 @@ describe('Stitcher', () => {
       const firstHash = entities[0].hash;
 
       const search = await db<DbSearchRow>('search');
+      const stitch_expected_array = [
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'relations.looksat',
+          original_value: 'k:ns/other',
+          value: 'k:ns/other',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'apiversion',
+          original_value: 'a',
+          value: 'a',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'kind',
+          original_value: 'k',
+          value: 'k',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'metadata.name',
+          original_value: 'n',
+          value: 'n',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'metadata.namespace',
+          original_value: 'ns',
+          value: 'ns',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'metadata.uid',
+          original_value: 'my-id',
+          value: 'my-id',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'spec.k',
+          original_value: 'v',
+          value: 'v',
+        },
+      ];
+
+      const sqlite_stitch_expected_array = [
+        {
+          entity_id: 'my-id',
+          key: 'relations.looksat',
+          original_value: 'k:ns/other',
+          value: 'k:ns/other',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'apiversion',
+          original_value: 'a',
+          value: 'a',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'kind',
+          original_value: 'k',
+          value: 'k',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'metadata.name',
+          original_value: 'n',
+          value: 'n',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'metadata.namespace',
+          original_value: 'ns',
+          value: 'ns',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'metadata.uid',
+          original_value: 'my-id',
+          value: 'my-id',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'spec.k',
+          original_value: 'v',
+          value: 'v',
+        },
+      ];
+
       expect(search).toEqual(
-        expect.arrayContaining([
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'relations.looksat',
-            original_value: 'k:ns/other',
-            value: 'k:ns/other',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'apiversion',
-            original_value: 'a',
-            value: 'a',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'kind',
-            original_value: 'k',
-            value: 'k',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'metadata.name',
-            original_value: 'n',
-            value: 'n',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'metadata.namespace',
-            original_value: 'ns',
-            value: 'ns',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'metadata.uid',
-            original_value: 'my-id',
-            value: 'my-id',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'spec.k',
-            original_value: 'v',
-            value: 'v',
-          },
-        ]),
+        expect.arrayContaining(
+          databaseId === 'SQLITE_3'
+            ? sqlite_stitch_expected_array
+            : stitch_expected_array,
+        ),
       );
 
       // Re-stitch without any changes
@@ -227,65 +278,122 @@ describe('Stitcher', () => {
       expect(entities[0].hash).not.toEqual(firstHash);
       expect(entities[0].hash).toEqual(entity.metadata.etag);
 
+      const restitch_expected_array = [
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'relations.looksat',
+          original_value: 'k:ns/other',
+          value: 'k:ns/other',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'relations.looksat',
+          original_value: 'k:ns/third',
+          value: 'k:ns/third',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'apiversion',
+          original_value: 'a',
+          value: 'a',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'kind',
+          original_value: 'k',
+          value: 'k',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'metadata.name',
+          original_value: 'n',
+          value: 'n',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'metadata.namespace',
+          original_value: 'ns',
+          value: 'ns',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'metadata.uid',
+          original_value: 'my-id',
+          value: 'my-id',
+        },
+        {
+          entity_id: 'my-id',
+          id: expect.anything(),
+          key: 'spec.k',
+          original_value: 'v',
+          value: 'v',
+        },
+      ];
+
+      const sqlite_restitch_expected_array = [
+        {
+          entity_id: 'my-id',
+          key: 'relations.looksat',
+          original_value: 'k:ns/other',
+          value: 'k:ns/other',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'relations.looksat',
+          original_value: 'k:ns/third',
+          value: 'k:ns/third',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'apiversion',
+          original_value: 'a',
+          value: 'a',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'kind',
+          original_value: 'k',
+          value: 'k',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'metadata.name',
+          original_value: 'n',
+          value: 'n',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'metadata.namespace',
+          original_value: 'ns',
+          value: 'ns',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'metadata.uid',
+          original_value: 'my-id',
+          value: 'my-id',
+        },
+        {
+          entity_id: 'my-id',
+          key: 'spec.k',
+          original_value: 'v',
+          value: 'v',
+        },
+      ];
+
       expect(await db<DbSearchRow>('search')).toEqual(
-        expect.arrayContaining([
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'relations.looksat',
-            original_value: 'k:ns/other',
-            value: 'k:ns/other',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'relations.looksat',
-            original_value: 'k:ns/third',
-            value: 'k:ns/third',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'apiversion',
-            original_value: 'a',
-            value: 'a',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'kind',
-            original_value: 'k',
-            value: 'k',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'metadata.name',
-            original_value: 'n',
-            value: 'n',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'metadata.namespace',
-            original_value: 'ns',
-            value: 'ns',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'metadata.uid',
-            original_value: 'my-id',
-            value: 'my-id',
-          },
-          {
-            entity_id: 'my-id',
-            id: expect.anything(),
-            key: 'spec.k',
-            original_value: 'v',
-            value: 'v',
-          },
-        ]),
+        expect.arrayContaining(
+          databaseId === 'SQLITE_3'
+            ? sqlite_restitch_expected_array
+            : restitch_expected_array,
+        ),
       );
     },
   );


### PR DESCRIPTION
Updating tests to account for missing pk column `id` in sqlite dbs.

Updated Tests: 
CI=1 yarn test plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
CI=1 yarn test plugins/catalog-backend/src/database/operations/stitcher/performStitching.test.ts
CI=1 yarn test plugins/catalog-backend/src/stitching/DefaultStitcher.test.ts